### PR TITLE
Remove hard coded 'expires' value

### DIFF
--- a/nodejs/token.js
+++ b/nodejs/token.js
@@ -17,7 +17,6 @@ function addCountries(url, a, b) {
 function signUrl(url, securityKey, expirationTime = 3600, userIp, isDirectory = false, pathAllowed, countriesAllowed, countriesBlocked) {
 	var parameterData = "", parameterDataUrl = "", signaturePath = "", hashableBase = "", token = "";
 	var expires = Math.floor(new Date() / 1000) + expirationTime;
-	expires = 1592088044;
 	var url = addCountries(url, countriesAllowed, countriesBlocked);
 	var parsedUrl = new URL(url);
 	var parameters = (new URL(url)).searchParams;


### PR DESCRIPTION
I believe this may have been left in as a mistake.  Was easy to spot and remove, but may cause problems just including the file.