### PR TITLE
decode the pathname

### DIFF
--- a/nodejs/token.js
+++ b/nodejs/token.js
@@ -24,7 +24,7 @@ function signUrl(url, securityKey, expirationTime = 3600, userIp, isDirectory = 
 		signaturePath = pathAllowed;
 		parameters.set("token_path", signaturePath);
 	} else {
-		signaturePath = parsedUrl.pathname;
+		signaturePath = decodeURIComponent(parsedUrl.pathname);
 	}
 	parameters.sort()
 	if (Array.from(parameters).length > 0) {


### PR DESCRIPTION
URL() encodes the pathname per: https://developer.mozilla.org/en-US/docs/Web/API/URL#usage_notes 

This wraps the signing path in decodeURIComponent to allow signing of paths which have characters that would have been encoded for the signature.