### PR TITLE
Update clients to allow for binary IP validation

### DIFF
--- a/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication.Tests/BunnyCDN.TokenAuthentication.Tests.csproj
+++ b/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication.Tests/BunnyCDN.TokenAuthentication.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication.Tests/TokenSignerTests.cs
+++ b/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication.Tests/TokenSignerTests.cs
@@ -57,7 +57,7 @@ namespace BunnyCDN.TokenAuthentication.Tests
                 t.UserIp = "1.2.3.4";
             });
 
-            url.ShouldBe("https://token-tester.b-cdn.net/300kb.jpg?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk&expires=1598024587");
+            url.ShouldBe("https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk&expires=1598024587");
         }
 
         [Test]
@@ -71,7 +71,28 @@ namespace BunnyCDN.TokenAuthentication.Tests
                 t.UserIp = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
             });
 
-            url.ShouldBe("https://token-tester.b-cdn.net/300kb.jpg?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U&expires=1598024587");
+            url.ShouldBe("https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60&expires=1598024587");
+        }
+
+        [Test]
+        public void IPv6CompressedFormMatchesExpanded()
+        {
+            var expanded = TokenSigner.SignUrl(t =>
+            {
+                t.Url = "https://token-tester.b-cdn.net/300kb.jpg";
+                t.SecurityKey = SecurityKey;
+                t.ExpiresAt = ExpiresAtGlobal;
+                t.UserIp = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+            });
+            var compressed = TokenSigner.SignUrl(t =>
+            {
+                t.Url = "https://token-tester.b-cdn.net/300kb.jpg";
+                t.SecurityKey = SecurityKey;
+                t.ExpiresAt = ExpiresAtGlobal;
+                t.UserIp = "2001:db8:85a3::8a2e:370:7334";
+            });
+
+            compressed.ShouldBe(expanded);
         }
 
         [Test]
@@ -87,7 +108,7 @@ namespace BunnyCDN.TokenAuthentication.Tests
                 t.CountriesAllowed = new List<string> { "CA", "US" };
             });
 
-            url.ShouldBe("https://token-tester.b-cdn.net/bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk&token_countries=CA%2CUS&expires=1598024587/abc/");
+            url.ShouldBe("https://token-tester.b-cdn.net/bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E&token_countries=CA%2CUS&expires=1598024587/abc/");
         }
 
         [Test]
@@ -191,7 +212,7 @@ namespace BunnyCDN.TokenAuthentication.Tests
                 t.CountriesAllowed = new List<string> { "CA", "US" };
             });
 
-            url.ShouldBe("https://token-tester.b-cdn.net/bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA&token_countries=CA%2CUS&expires=1598024587/abc/");
+            url.ShouldBe("https://token-tester.b-cdn.net/bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o&token_countries=CA%2CUS&expires=1598024587/abc/");
         }
 
         [Test]
@@ -239,7 +260,7 @@ namespace BunnyCDN.TokenAuthentication.Tests
                 t.SpeedLimit = 5000;
             });
 
-            url.ShouldBe("https://token-tester.b-cdn.net/bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I&limit=5000&expires=1598024587/abc/");
+            url.ShouldBe("https://token-tester.b-cdn.net/bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ&limit=5000&expires=1598024587/abc/");
         }
 
         [Test]
@@ -262,6 +283,32 @@ namespace BunnyCDN.TokenAuthentication.Tests
                 {
                     t.Url = "https://token-tester.b-cdn.net/300kb.jpg";
                     t.SecurityKey = SecurityKey;
+                }));
+        }
+
+        [Test]
+        public void NoUserIpOmitsFlagPrefix()
+        {
+            var url = TokenSigner.SignUrl(t =>
+            {
+                t.Url = "https://token-tester.b-cdn.net/300kb.jpg";
+                t.SecurityKey = SecurityKey;
+                t.ExpiresAt = ExpiresAtGlobal;
+            });
+
+            url.ShouldNotContain("HS256-1-");
+        }
+
+        [Test]
+        public void InvalidIpThrows()
+        {
+            Should.Throw<ArgumentException>(() =>
+                TokenSigner.SignUrl(t =>
+                {
+                    t.Url = "https://token-tester.b-cdn.net/300kb.jpg";
+                    t.SecurityKey = SecurityKey;
+                    t.ExpiresAt = ExpiresAtGlobal;
+                    t.UserIp = "not-an-ip";
                 }));
         }
     }

--- a/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication.csproj
+++ b/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication/TokenSigner.cs
+++ b/c#/BunnyCDN.TokenAuthentication/BunnyCDN.TokenAuthentication/TokenSigner.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -38,8 +41,10 @@ namespace BunnyCDN.TokenAuthentication
             var signingData = JoinParams(parameters, encode: false);
             var urlData = JoinParams(parameters, encode: true);
 
-            var message = string.Concat(signaturePath, expires, signingData, config.UserIp);
-            var token = "HS256-" + HmacSha256Base64Url(config.SecurityKey, message);
+            var hasIp = !string.IsNullOrEmpty(config.UserIp);
+            var message = BuildMessageBytes(signaturePath, expires, signingData, config.UserIp, hasIp);
+            var flagsPrefix = hasIp ? "1-" : "";
+            var token = "HS256-" + flagsPrefix + HmacSha256Base64Url(config.SecurityKey, message);
 
             var baseUrl = string.Concat(uri.Scheme, "://", uri.Authority);
             var tail = urlData.Length > 0 ? string.Concat("&", urlData) : "";
@@ -72,6 +77,40 @@ namespace BunnyCDN.TokenAuthentication
 
         public static string SignUrl(string securityKey, Uri url, DateTimeOffset expireAt, string ipAddress)
             => SignUrl(securityKey, url.ToString(), expireAt, ipAddress);
+
+        private static byte[] BuildMessageBytes(
+            string signaturePath, string expires, string signingData, string userIp, bool hasIp)
+        {
+            var ms = new MemoryStream();
+            var pathBytes = Encoding.UTF8.GetBytes(signaturePath);
+            ms.Write(pathBytes, 0, pathBytes.Length);
+
+            var expiresBytes = Encoding.UTF8.GetBytes(expires);
+            ms.Write(expiresBytes, 0, expiresBytes.Length);
+
+            var signingBytes = Encoding.UTF8.GetBytes(signingData);
+            ms.Write(signingBytes, 0, signingBytes.Length);
+
+            if (hasIp)
+            {
+                var ipBytes = GetUserIpBytes(userIp);
+                ms.Write(ipBytes, 0, ipBytes.Length);
+            }
+
+            return ms.ToArray();
+        }
+
+        private static byte[] GetUserIpBytes(string userIp)
+        {
+            if (!IPAddress.TryParse(userIp, out var addr))
+                throw new ArgumentException($"UserIp '{userIp}' is not a valid IP address.", nameof(userIp));
+
+            if (addr.AddressFamily != AddressFamily.InterNetwork &&
+                addr.AddressFamily != AddressFamily.InterNetworkV6)
+                throw new ArgumentException($"UserIp '{userIp}' has unsupported address family {addr.AddressFamily}.", nameof(userIp));
+
+            return addr.GetAddressBytes();
+        }
 
         private static SortedDictionary<string, string> BuildParameters(
             Dictionary<string, string> queryParams,
@@ -157,31 +196,25 @@ namespace BunnyCDN.TokenAuthentication
         }
 
 #if NET6_0_OR_GREATER
-        private static string HmacSha256Base64Url(string key, string message)
+        private static string HmacSha256Base64Url(string key, byte[] message)
         {
             Span<byte> hash = stackalloc byte[32];
 
             var keyLen = Encoding.UTF8.GetByteCount(key);
-            var msgLen = Encoding.UTF8.GetByteCount(message);
 
-            byte[] rentedKey = null, rentedMsg = null;
+            byte[] rentedKey = null;
             var keyBytes = keyLen <= 256
                 ? stackalloc byte[keyLen]
                 : (rentedKey = System.Buffers.ArrayPool<byte>.Shared.Rent(keyLen)).AsSpan(0, keyLen);
-            var msgBytes = msgLen <= 1024
-                ? stackalloc byte[msgLen]
-                : (rentedMsg = System.Buffers.ArrayPool<byte>.Shared.Rent(msgLen)).AsSpan(0, msgLen);
 
             try
             {
                 Encoding.UTF8.GetBytes(key, keyBytes);
-                Encoding.UTF8.GetBytes(message, msgBytes);
-                HMACSHA256.HashData(keyBytes, msgBytes, hash);
+                HMACSHA256.HashData(keyBytes, message, hash);
             }
             finally
             {
                 if (rentedKey != null) System.Buffers.ArrayPool<byte>.Shared.Return(rentedKey);
-                if (rentedMsg != null) System.Buffers.ArrayPool<byte>.Shared.Return(rentedMsg);
             }
 
             return Base64UrlNopad(hash);
@@ -204,11 +237,11 @@ namespace BunnyCDN.TokenAuthentication
             return new string(buf.Slice(0, written));
         }
 #else
-        private static string HmacSha256Base64Url(string key, string message)
+        private static string HmacSha256Base64Url(string key, byte[] message)
         {
             using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(key)))
             {
-                var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(message));
+                var hash = hmac.ComputeHash(message);
                 return Convert.ToBase64String(hash)
                     .Replace('+', '-')
                     .Replace('/', '_')

--- a/go/token.go
+++ b/go/token.go
@@ -1,3 +1,4 @@
+// Package bunnycdn implements BunnyCDN URL token authentication.
 package bunnycdn
 
 import (
@@ -6,11 +7,15 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"sort"
 	"strings"
 	"time"
 )
+
+// Version is the SDK release version.
+const Version = "2.1.0"
 
 // SignUrl generates a signed BunnyCDN URL using HMAC-SHA256 token authentication.
 //
@@ -136,11 +141,22 @@ func SignUrl(
 	signingData := strings.Join(signingParts, "&")
 	urlData := strings.Join(urlParts, "&")
 
-	// HMAC-SHA256.
-	message := signaturePath + expires + signingData + userIp
+	flagsPrefix := ""
+	var ipBytes []byte
+	if userIp != "" {
+		ipBytes, err = userIpBytes(userIp)
+		if err != nil {
+			return "", err
+		}
+		flagsPrefix = "1-"
+	}
+
 	mac := hmac.New(sha256.New, []byte(securityKey))
-	mac.Write([]byte(message))
-	token := "HS256-" + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	mac.Write([]byte(signaturePath))
+	mac.Write([]byte(expires))
+	mac.Write([]byte(signingData))
+	mac.Write(ipBytes)
+	token := "HS256-" + flagsPrefix + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
 
 	// Build final URL.
 	base := parsed.Scheme + "://" + parsed.Host
@@ -157,4 +173,17 @@ func SignUrl(
 
 func percentEncode(s string) string {
 	return strings.ReplaceAll(url.QueryEscape(s), "+", "%20")
+}
+
+func userIpBytes(userIp string) ([]byte, error) {
+	ip := net.ParseIP(userIp)
+	if ip == nil {
+		return nil, fmt.Errorf("userIp %q is not a valid IP address", userIp)
+	}
+	// net.ParseIP returns a 16-byte IPv4-mapped slice for "1.2.3.4"; the
+	// 4-byte form is what callers expect.
+	if v4 := ip.To4(); v4 != nil {
+		return v4, nil
+	}
+	return ip.To16(), nil
 }

--- a/go/token_test.go
+++ b/go/token_test.go
@@ -1,6 +1,9 @@
 package bunnycdn
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const securityKey = "SecurityKey"
 
@@ -42,7 +45,7 @@ func TestWithIPAddress(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk&expires=1598024587"
+	expected := "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk&expires=1598024587"
 	if result != expected {
 		t.Errorf("got %s, want %s", result, expected)
 	}
@@ -56,9 +59,29 @@ func TestWithIPv6Address(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U&expires=1598024587"
+	expected := "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60&expires=1598024587"
 	if result != expected {
 		t.Errorf("got %s, want %s", result, expected)
+	}
+}
+
+func TestIPv6CompressedFormMatchesExpanded(t *testing.T) {
+	expanded, err := SignUrl(
+		"https://token-tester.b-cdn.net/300kb.jpg",
+		securityKey, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", false, "", "", "", false, &expiresAt, 0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed, err := SignUrl(
+		"https://token-tester.b-cdn.net/300kb.jpg",
+		securityKey, 86400, "2001:db8:85a3::8a2e:370:7334", false, "", "", "", false, &expiresAt, 0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compressed != expanded {
+		t.Errorf("compressed %s != expanded %s", compressed, expanded)
 	}
 }
 
@@ -70,7 +93,7 @@ func TestCombinedIPv6CountryDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "https://token-tester.b-cdn.net/bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk&token_countries=CA%2CUS&expires=1598024587/abc/"
+	expected := "https://token-tester.b-cdn.net/bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E&token_countries=CA%2CUS&expires=1598024587/abc/"
 	if result != expected {
 		t.Errorf("got %s, want %s", result, expected)
 	}
@@ -154,7 +177,7 @@ func TestCombinedIPCountryDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "https://token-tester.b-cdn.net/bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA&token_countries=CA%2CUS&expires=1598024587/abc/"
+	expected := "https://token-tester.b-cdn.net/bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o&token_countries=CA%2CUS&expires=1598024587/abc/"
 	if result != expected {
 		t.Errorf("got %s, want %s", result, expected)
 	}
@@ -182,7 +205,7 @@ func TestCombinedSpeedLimitIPDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "https://token-tester.b-cdn.net/bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I&limit=5000&expires=1598024587/abc/"
+	expected := "https://token-tester.b-cdn.net/bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ&limit=5000&expires=1598024587/abc/"
 	if result != expected {
 		t.Errorf("got %s, want %s", result, expected)
 	}
@@ -199,5 +222,28 @@ func TestValidationNegativeExpiry(t *testing.T) {
 	_, err := SignUrl("https://example.com/f.jpg", "key", -1, "", false, "", "", "", false, nil, 0)
 	if err == nil {
 		t.Error("expected error for negative expiration time")
+	}
+}
+
+func TestNoUserIpOmitsFlagPrefix(t *testing.T) {
+	result, err := SignUrl(
+		"https://token-tester.b-cdn.net/300kb.jpg",
+		securityKey, 86400, "", false, "", "", "", false, &expiresAt, 0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(result, "HS256-1-") {
+		t.Errorf("expected no HS256-1- flag prefix when userIp is empty, got %s", result)
+	}
+}
+
+func TestInvalidIpReturnsError(t *testing.T) {
+	_, err := SignUrl(
+		"https://token-tester.b-cdn.net/300kb.jpg",
+		securityKey, 86400, "not-an-ip", false, "", "", "", false, &expiresAt, 0,
+	)
+	if err == nil {
+		t.Error("expected error for invalid userIp")
 	}
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.bunnycdn</groupId>
     <artifactId>token-authentication</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>BunnyCDN Token Authentication</name>

--- a/java/src/main/java/BunnyCDN/TokenSigner.java
+++ b/java/src/main/java/BunnyCDN/TokenSigner.java
@@ -2,13 +2,18 @@ package BunnyCDN;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 
 public class TokenSigner {
 
@@ -170,18 +175,24 @@ public class TokenSigner {
                 urlData.append(entry.getKey()).append('=').append(encodedValue);
             }
 
-            // Step 9: message
-            String message = signaturePath + expires + signingData + userIp;
+            // Step 9: HMAC-SHA256
+            boolean hasIp = userIp != null && !userIp.isEmpty();
+            byte[] ipBytes = hasIp ? userIpToBytes(userIp) : new byte[0];
+            String flagsPrefix = hasIp ? "1-" : "";
 
-            // Step 10: HMAC-SHA256
             Mac mac = Mac.getInstance("HmacSHA256");
             SecretKeySpec keySpec = new SecretKeySpec(
                     securityKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
             mac.init(keySpec);
-            byte[] digest = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+            mac.update(signaturePath.getBytes(StandardCharsets.UTF_8));
+            mac.update(expires.getBytes(StandardCharsets.UTF_8));
+            mac.update(signingData.toString().getBytes(StandardCharsets.UTF_8));
+            mac.update(ipBytes);
+            byte[] digest = mac.doFinal();
 
-            // Step 11: token
-            String token = "HS256-" + Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+            // Step 10: token
+            String token = "HS256-" + flagsPrefix
+                    + Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
 
             // Step 12: Build final URL
             String base = uri.getScheme() + "://" + uri.getHost();
@@ -198,6 +209,25 @@ public class TokenSigner {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException("Failed to sign URL", e);
+        }
+    }
+
+    private static final Pattern IPV4_LITERAL = Pattern.compile("^[0-9.]+$");
+    private static final Pattern IPV6_LITERAL = Pattern.compile("^[0-9A-Fa-f:.]+$");
+
+    private static byte[] userIpToBytes(String userIp) {
+        if (userIp == null || userIp.isEmpty()) {
+            throw new IllegalArgumentException("userIp must not be empty");
+        }
+        boolean looksLikeIp = IPV4_LITERAL.matcher(userIp).matches()
+                || (userIp.indexOf(':') >= 0 && IPV6_LITERAL.matcher(userIp).matches());
+        if (!looksLikeIp) {
+            throw new IllegalArgumentException("userIp '" + userIp + "' is not a valid IP address");
+        }
+        try {
+            return InetAddress.getByName(userIp).getAddress();
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("userIp '" + userIp + "' is not a valid IP address", e);
         }
     }
 }

--- a/java/src/test/java/BunnyCDN/TokenSignerTest.java
+++ b/java/src/test/java/BunnyCDN/TokenSignerTest.java
@@ -39,7 +39,7 @@ class TokenSignerTest {
             SECURITY_KEY, 86400, "1.2.3.4", false, null, null, null, false, EXPIRES_AT
         );
         assertEquals(
-            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk&expires=1598024587",
+            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk&expires=1598024587",
             result
         );
     }
@@ -51,9 +51,22 @@ class TokenSignerTest {
             SECURITY_KEY, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", false, null, null, null, false, EXPIRES_AT
         );
         assertEquals(
-            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U&expires=1598024587",
+            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60&expires=1598024587",
             result
         );
+    }
+
+    @Test
+    void testIPv6CompressedFormMatchesExpanded() {
+        String expanded = TokenSigner.signUrl(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", false, null, null, null, false, EXPIRES_AT
+        );
+        String compressed = TokenSigner.signUrl(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "2001:db8:85a3::8a2e:370:7334", false, null, null, null, false, EXPIRES_AT
+        );
+        assertEquals(expanded, compressed);
     }
 
     @Test
@@ -63,7 +76,7 @@ class TokenSignerTest {
             SECURITY_KEY, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", true, null, "CA,US", null, false, EXPIRES_AT
         );
         assertEquals(
-            "https://token-tester.b-cdn.net/bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk&token_countries=CA%2CUS&expires=1598024587/abc/",
+            "https://token-tester.b-cdn.net/bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E&token_countries=CA%2CUS&expires=1598024587/abc/",
             result
         );
     }
@@ -135,7 +148,7 @@ class TokenSignerTest {
             SECURITY_KEY, 86400, "1.2.3.4", true, null, "CA,US", null, false, EXPIRES_AT
         );
         assertEquals(
-            "https://token-tester.b-cdn.net/bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA&token_countries=CA%2CUS&expires=1598024587/abc/",
+            "https://token-tester.b-cdn.net/bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o&token_countries=CA%2CUS&expires=1598024587/abc/",
             result
         );
     }
@@ -159,7 +172,7 @@ class TokenSignerTest {
             SECURITY_KEY, 86400, "1.2.3.4", true, null, null, null, false, EXPIRES_AT, 5000
         );
         assertEquals(
-            "https://token-tester.b-cdn.net/bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I&limit=5000&expires=1598024587/abc/",
+            "https://token-tester.b-cdn.net/bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ&limit=5000&expires=1598024587/abc/",
             result
         );
     }
@@ -175,6 +188,25 @@ class TokenSignerTest {
     void testValidationNegativeExpiry() {
         assertThrows(IllegalArgumentException.class, () ->
             TokenSigner.signUrl("https://example.com/f.jpg", "key", -1, "", false, null, null, null)
+        );
+    }
+
+    @Test
+    void testNoUserIpOmitsFlagPrefix() {
+        String result = TokenSigner.signUrl(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "", false, null, null, null, false, EXPIRES_AT
+        );
+        assertFalse(result.contains("HS256-1-"));
+    }
+
+    @Test
+    void testInvalidIpThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+            TokenSigner.signUrl(
+                "https://token-tester.b-cdn.net/300kb.jpg",
+                SECURITY_KEY, 86400, "not-an-ip", false, null, null, null, false, EXPIRES_AT
+            )
         );
     }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunnycdn-token-authentication",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "token.js",
   "scripts": {
     "test": "node --test token.test.js"

--- a/nodejs/token.js
+++ b/nodejs/token.js
@@ -1,4 +1,79 @@
 const crypto = require('crypto');
+const net = require('net');
+
+function userIpToBytes(userIp) {
+    const family = net.isIP(userIp);
+    if (family === 4) {
+        const parts = userIp.split('.');
+        if (parts.length !== 4) {
+            throw new Error(`userIp '${userIp}' is not a valid IP address`);
+        }
+        const buf = Buffer.alloc(4);
+        for (let i = 0; i < 4; i++) {
+            const n = Number(parts[i]);
+            if (!Number.isInteger(n) || n < 0 || n > 255) {
+                throw new Error(`userIp '${userIp}' is not a valid IP address`);
+            }
+            buf[i] = n;
+        }
+        return buf;
+    }
+    if (family === 6) {
+        return parseIpv6(userIp);
+    }
+    throw new Error(`userIp '${userIp}' is not a valid IP address`);
+}
+
+function parseIpv6(str) {
+    let trailingV4 = null;
+    const lastColon = str.lastIndexOf(':');
+    if (lastColon !== -1 && str.indexOf('.') > lastColon) {
+        const tail = str.slice(lastColon + 1);
+        if (net.isIP(tail) !== 4) {
+            throw new Error(`userIp '${str}' is not a valid IP address`);
+        }
+        trailingV4 = tail.split('.').map(Number);
+        str = str.slice(0, lastColon) + ':0:0';
+    }
+
+    const halves = str.split('::');
+    if (halves.length > 2) {
+        throw new Error(`userIp '${str}' is not a valid IP address`);
+    }
+
+    const left = halves[0] === '' ? [] : halves[0].split(':');
+    const right = halves.length === 2 && halves[1] !== '' ? halves[1].split(':') : [];
+    const totalGiven = left.length + right.length;
+
+    if (halves.length === 1 && totalGiven !== 8) {
+        throw new Error(`userIp '${str}' is not a valid IP address`);
+    }
+    if (halves.length === 2 && totalGiven > 7) {
+        throw new Error(`userIp '${str}' is not a valid IP address`);
+    }
+
+    const fillCount = halves.length === 2 ? 8 - totalGiven : 0;
+    const hextets = [...left, ...Array(fillCount).fill('0'), ...right];
+    if (hextets.length !== 8) {
+        throw new Error(`userIp '${str}' is not a valid IP address`);
+    }
+
+    const buf = Buffer.alloc(16);
+    for (let i = 0; i < 8; i++) {
+        const h = hextets[i];
+        if (!/^[0-9A-Fa-f]{1,4}$/.test(h)) {
+            throw new Error(`userIp '${str}' is not a valid IP address`);
+        }
+        const n = parseInt(h, 16);
+        buf[i * 2] = (n >>> 8) & 0xff;
+        buf[i * 2 + 1] = n & 0xff;
+    }
+
+    if (trailingV4) {
+        for (let i = 0; i < 4; i++) buf[12 + i] = trailingV4[i];
+    }
+    return buf;
+}
 
 /**
  * Generate a signed BunnyCDN URL.
@@ -85,14 +160,20 @@ function signUrl(
     // 8. urlData (encoded values)
     const urlData = sortedEntries.map(([k, v]) => `${k}=${encodeURIComponent(v)}`).join('&');
 
-    // 9. message
-    const message = `${signaturePath}${expires}${signingData}${userIp}`;
+    // 9. HMAC-SHA256
+    const hasIp = !!userIp;
+    const ipBytes = hasIp ? userIpToBytes(userIp) : Buffer.alloc(0);
+    const flagsPrefix = hasIp ? '1-' : '';
 
-    // 10. HMAC-SHA256
-    const digest = crypto.createHmac('sha256', securityKey).update(message).digest();
+    const hmac = crypto.createHmac('sha256', securityKey);
+    hmac.update(signaturePath);
+    hmac.update(expires);
+    hmac.update(signingData);
+    hmac.update(ipBytes);
+    const digest = hmac.digest();
 
-    // 11. token
-    const token = 'HS256-' + digest.toString('base64')
+    // 10. token
+    const token = 'HS256-' + flagsPrefix + digest.toString('base64')
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/=+$/, '');

--- a/nodejs/token.test.js
+++ b/nodejs/token.test.js
@@ -30,7 +30,7 @@ describe('signUrl', () => {
             SECURITY_KEY, 86400, '1.2.3.4', false, '', '', '', false, EXPIRES_AT,
         );
         assert.equal(result,
-            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk&expires=1598024587');
+            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk&expires=1598024587');
     });
 
     it('with IPv6 address', () => {
@@ -39,7 +39,19 @@ describe('signUrl', () => {
             SECURITY_KEY, 86400, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', false, '', '', '', false, EXPIRES_AT,
         );
         assert.equal(result,
-            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U&expires=1598024587');
+            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60&expires=1598024587');
+    });
+
+    it('compressed IPv6 form matches expanded', () => {
+        const expanded = signUrl(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            SECURITY_KEY, 86400, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', false, '', '', '', false, EXPIRES_AT,
+        );
+        const compressed = signUrl(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            SECURITY_KEY, 86400, '2001:db8:85a3::8a2e:370:7334', false, '', '', '', false, EXPIRES_AT,
+        );
+        assert.equal(compressed, expanded);
     });
 
     it('combined IPv6, country, and directory', () => {
@@ -48,7 +60,7 @@ describe('signUrl', () => {
             SECURITY_KEY, 86400, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', true, '', 'CA,US', '', false, EXPIRES_AT,
         );
         assert.equal(result,
-            'https://token-tester.b-cdn.net/bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk&token_countries=CA%2CUS&expires=1598024587/abc/');
+            'https://token-tester.b-cdn.net/bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E&token_countries=CA%2CUS&expires=1598024587/abc/');
     });
 
     it('with path allowed', () => {
@@ -102,7 +114,7 @@ describe('signUrl', () => {
             SECURITY_KEY, 86400, '1.2.3.4', true, '', 'CA,US', '', false, EXPIRES_AT,
         );
         assert.equal(result,
-            'https://token-tester.b-cdn.net/bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA&token_countries=CA%2CUS&expires=1598024587/abc/');
+            'https://token-tester.b-cdn.net/bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o&token_countries=CA%2CUS&expires=1598024587/abc/');
     });
 
     it('with speed limit', () => {
@@ -120,7 +132,7 @@ describe('signUrl', () => {
             SECURITY_KEY, 86400, '1.2.3.4', true, '', '', '', false, EXPIRES_AT, 5000,
         );
         assert.equal(result,
-            'https://token-tester.b-cdn.net/bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I&limit=5000&expires=1598024587/abc/');
+            'https://token-tester.b-cdn.net/bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ&limit=5000&expires=1598024587/abc/');
     });
 
     it('throws on empty securityKey', () => {
@@ -129,5 +141,20 @@ describe('signUrl', () => {
 
     it('throws on negative expirationTime', () => {
         assert.throws(() => signUrl('https://example.com/f.jpg', 'key', -1), /expirationTime/);
+    });
+
+    it('no userIp omits flag prefix', () => {
+        const result = signUrl(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            SECURITY_KEY, 86400, '', false, '', '', '', false, EXPIRES_AT,
+        );
+        assert.ok(!result.includes('HS256-1-'));
+    });
+
+    it('throws on invalid userIp', () => {
+        assert.throws(() => signUrl(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            SECURITY_KEY, 86400, 'not-an-ip', false, '', '', '', false, EXPIRES_AT,
+        ));
     });
 });

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,4 +1,5 @@
 {
+    "version": "2.1.0",
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0"
     },

--- a/php/tests/TokenSignerTest.php
+++ b/php/tests/TokenSignerTest.php
@@ -46,7 +46,7 @@ class TokenSignerTest extends TestCase
         );
 
         $this->assertSame(
-            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk&expires=1598024587',
+            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk&expires=1598024587',
             $result
         );
     }
@@ -60,9 +60,24 @@ class TokenSignerTest extends TestCase
         );
 
         $this->assertSame(
-            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U&expires=1598024587',
+            'https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60&expires=1598024587',
             $result
         );
+    }
+
+    public function testIPv6CompressedFormMatchesExpanded(): void
+    {
+        $expanded = sign_bcdn_url(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            self::SECURITY_KEY, 86400, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', false, '', '', '', false,
+            self::EXPIRES_AT
+        );
+        $compressed = sign_bcdn_url(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            self::SECURITY_KEY, 86400, '2001:db8:85a3::8a2e:370:7334', false, '', '', '', false,
+            self::EXPIRES_AT
+        );
+        $this->assertSame($expanded, $compressed);
     }
 
     public function testCombinedIPv6CountryDirectory(): void
@@ -74,7 +89,7 @@ class TokenSignerTest extends TestCase
         );
 
         $this->assertSame(
-            'https://token-tester.b-cdn.net/bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk&token_countries=CA%2CUS&expires=1598024587/abc/',
+            'https://token-tester.b-cdn.net/bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E&token_countries=CA%2CUS&expires=1598024587/abc/',
             $result
         );
     }
@@ -158,7 +173,7 @@ class TokenSignerTest extends TestCase
         );
 
         $this->assertSame(
-            'https://token-tester.b-cdn.net/bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA&token_countries=CA%2CUS&expires=1598024587/abc/',
+            'https://token-tester.b-cdn.net/bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o&token_countries=CA%2CUS&expires=1598024587/abc/',
             $result
         );
     }
@@ -186,7 +201,7 @@ class TokenSignerTest extends TestCase
         );
 
         $this->assertSame(
-            'https://token-tester.b-cdn.net/bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I&limit=5000&expires=1598024587/abc/',
+            'https://token-tester.b-cdn.net/bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ&limit=5000&expires=1598024587/abc/',
             $result
         );
     }
@@ -201,5 +216,25 @@ class TokenSignerTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         sign_bcdn_url('https://example.com/file.jpg', 'key', -1);
+    }
+
+    public function testNoUserIpOmitsFlagPrefix(): void
+    {
+        $result = sign_bcdn_url(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            self::SECURITY_KEY, 86400, '', false, '', '', '', false,
+            self::EXPIRES_AT
+        );
+        $this->assertStringNotContainsString('HS256-1-', $result);
+    }
+
+    public function testInvalidIpThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        sign_bcdn_url(
+            'https://token-tester.b-cdn.net/300kb.jpg',
+            self::SECURITY_KEY, 86400, 'not-an-ip', false, '', '', '', false,
+            self::EXPIRES_AT
+        );
     }
 }

--- a/php/url_signing.php
+++ b/php/url_signing.php
@@ -93,11 +93,15 @@ function sign_bcdn_url(
     $url_data = implode('&', $url_parts);
 
     // Build message and compute HMAC-SHA256
-    $message = $signature_path . $expires . $signing_data . $user_ip;
+    $has_ip = $user_ip !== '';
+    $ip_bytes = $has_ip ? user_ip_to_bytes($user_ip) : '';
+    $flags_prefix = $has_ip ? '1-' : '';
+
+    $message = $signature_path . $expires . $signing_data . $ip_bytes;
     $digest = hash_hmac('sha256', $message, $security_key, true);
 
     // Build token
-    $token = 'HS256-' . rtrim(strtr(base64_encode($digest), '+/', '-_'), '=');
+    $token = 'HS256-' . $flags_prefix . rtrim(strtr(base64_encode($digest), '+/', '-_'), '=');
 
     // Build final URL
     $base = "{$url_scheme}://{$url_host}";
@@ -108,4 +112,13 @@ function sign_bcdn_url(
     } else {
         return "{$base}{$url_path}?token={$token}{$tail}&expires={$expires}";
     }
+}
+
+function user_ip_to_bytes(string $user_ip): string
+{
+    $bytes = @inet_pton($user_ip);
+    if ($bytes === false) {
+        throw new InvalidArgumentException("user_ip '{$user_ip}' is not a valid IP address");
+    }
+    return $bytes;
 }

--- a/python3/test_token.py
+++ b/python3/test_token.py
@@ -54,7 +54,7 @@ def test_with_ip_address():
     )
     assert result == (
         "https://token-tester.b-cdn.net/300kb.jpg"
-        "?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk"
+        "?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk"
         "&expires=1598024587"
     )
 
@@ -67,9 +67,23 @@ def test_with_ipv6_address():
     )
     assert result == (
         "https://token-tester.b-cdn.net/300kb.jpg"
-        "?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U"
+        "?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60"
         "&expires=1598024587"
     )
+
+
+def test_ipv6_compressed_form_matches_expanded():
+    expanded = sign_url(
+        BASE_URL, SECURITY_KEY,
+        user_ip="2001:0db8:85a3:0000:0000:8a2e:0370:7334", is_directory=False,
+        expires_at=EXPIRES_AT,
+    )
+    compressed = sign_url(
+        BASE_URL, SECURITY_KEY,
+        user_ip="2001:db8:85a3::8a2e:370:7334", is_directory=False,
+        expires_at=EXPIRES_AT,
+    )
+    assert compressed == expanded
 
 
 def test_combined_ipv6_country_directory():
@@ -82,7 +96,7 @@ def test_combined_ipv6_country_directory():
     )
     assert result == (
         "https://token-tester.b-cdn.net/"
-        "bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk"
+        "bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E"
         "&token_countries=CA%2CUS&expires=1598024587/abc/"
     )
 
@@ -166,7 +180,7 @@ def test_combined_ip_country_directory():
     )
     assert result == (
         "https://token-tester.b-cdn.net/"
-        "bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA"
+        "bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o"
         "&token_countries=CA%2CUS&expires=1598024587/abc/"
     )
 
@@ -195,7 +209,7 @@ def test_combined_speed_limit_ip_directory():
     )
     assert result == (
         "https://token-tester.b-cdn.net/"
-        "bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I"
+        "bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ"
         "&limit=5000&expires=1598024587/abc/"
     )
 
@@ -208,3 +222,22 @@ def test_validation_empty_key():
 def test_validation_negative_expiry():
     with pytest.raises(ValueError, match="expiration_time"):
         sign_url(BASE_URL, SECURITY_KEY, expiration_time=-1)
+
+
+def test_no_user_ip_omits_flag_prefix():
+    result = sign_url(
+        BASE_URL, SECURITY_KEY,
+        is_directory=False,
+        expires_at=EXPIRES_AT,
+    )
+    assert "HS256-1-" not in result
+
+
+def test_invalid_ip_raises():
+    with pytest.raises(ValueError):
+        sign_url(
+            BASE_URL, SECURITY_KEY,
+            user_ip="not-an-ip",
+            is_directory=False,
+            expires_at=EXPIRES_AT,
+        )

--- a/python3/token.py
+++ b/python3/token.py
@@ -1,11 +1,14 @@
 """BunnyCDN URL token authentication."""
 
+import ipaddress
 import urllib.parse
 import time
 import hmac
 import hashlib
 import base64
 from typing import Dict, Optional
+
+__version__ = "2.1.0"
 
 
 def _b64url_no_pad(raw: bytes) -> str:
@@ -59,7 +62,8 @@ def sign_url(
         security_key:      Token Authentication Key from your PullZone settings.
         expiration_time:   Token validity in seconds (default 86400 / 24 h).
                            Ignored when expires_at is set.
-        user_ip:           Optional - lock the token to this IP.
+        user_ip:           Optional - lock the token to this IP. Must be a
+                           valid IPv4 or IPv6 address when supplied.
         is_directory:      True  → token embedded in path  (/bcdn_token=...)
                            False → token in query string   (?token=...)
         path_allowed:      Optional path override for the signature scope.
@@ -70,8 +74,8 @@ def sign_url(
                            overrides expiration_time.
 
     Raises:
-        ValueError: On empty/missing security_key, negative expiration, or
-                    multi-valued query parameters.
+        ValueError: On empty/missing security_key, negative expiration,
+                    multi-valued query parameters, or unparseable user_ip.
     """
 
     if not security_key:
@@ -110,13 +114,25 @@ def sign_url(
         f"{k}={urllib.parse.quote(v, safe='')}" for k, v in params.items()
     )
 
-    message = f"{signature_path}{expires}{signing_data}{user_ip}"
+    if user_ip:
+        ip_segment = ipaddress.ip_address(user_ip).packed
+        flags_prefix = "1-"
+    else:
+        ip_segment = b""
+        flags_prefix = ""
+
+    message = (
+        signature_path.encode("utf-8")
+        + expires.encode("utf-8")
+        + signing_data.encode("utf-8")
+        + ip_segment
+    )
     digest = hmac.new(
         security_key.encode("utf-8"),
-        message.encode("utf-8"),
+        message,
         hashlib.sha256,
     ).digest()
-    token = "HS256-" + _b64url_no_pad(digest)
+    token = "HS256-" + flags_prefix + _b64url_no_pad(digest)
 
     base = f"{parsed.scheme}://{parsed.netloc}"
     tail = f"&{url_data}" if url_data else ""

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bunnycdn-token-authentication"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 [dependencies]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::net::IpAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
@@ -132,12 +133,20 @@ pub fn sign_url(
         .join("&");
 
     // HMAC-SHA256.
-    let message = format!("{signature_path}{expires}{signing_data}{user_ip}");
+    let (ip_bytes, flags_prefix): (Vec<u8>, &str) = if user_ip.is_empty() {
+        (Vec::new(), "")
+    } else {
+        (user_ip_to_bytes(user_ip)?, "1-")
+    };
+
     let mut mac =
         HmacSha256::new_from_slice(security_key.as_bytes()).map_err(|e| e.to_string())?;
-    mac.update(message.as_bytes());
+    mac.update(signature_path.as_bytes());
+    mac.update(expires.as_bytes());
+    mac.update(signing_data.as_bytes());
+    mac.update(&ip_bytes);
     let digest = mac.finalize().into_bytes();
-    let token = format!("HS256-{}", URL_SAFE_NO_PAD.encode(digest));
+    let token = format!("HS256-{flags_prefix}{}", URL_SAFE_NO_PAD.encode(digest));
 
     // Build final URL.
     let base = format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap_or(""));
@@ -157,6 +166,16 @@ pub fn sign_url(
             "{base}{}?token={token}{tail}&expires={expires}",
             parsed.path()
         ))
+    }
+}
+
+fn user_ip_to_bytes(user_ip: &str) -> Result<Vec<u8>, String> {
+    let addr: IpAddr = user_ip
+        .parse()
+        .map_err(|_| format!("user_ip '{user_ip}' is not a valid IP address"))?;
+    match addr {
+        IpAddr::V4(v4) => Ok(v4.octets().to_vec()),
+        IpAddr::V6(v6) => Ok(v6.octets().to_vec()),
     }
 }
 
@@ -201,7 +220,7 @@ mod tests {
             SECURITY_KEY, 86400, "1.2.3.4", false, "", "", "", false, Some(EXPIRES_AT), 0,
         ).unwrap();
         assert_eq!(result,
-            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-0A9FRzMI9ACT-5VKMPbJf7g8f7UHavqjBH1Z8HljoEk&expires=1598024587");
+            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-L2rISTLcujMY9UFf2tbZ41d5i-Bme1g1oTK_Z2QMLJk&expires=1598024587");
     }
 
     #[test]
@@ -211,7 +230,20 @@ mod tests {
             SECURITY_KEY, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", false, "", "", "", false, Some(EXPIRES_AT), 0,
         ).unwrap();
         assert_eq!(result,
-            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-7CEOZ-eY9DjC36ZnazCM3Ykj3-bR6h9V_IncIVT2s2U&expires=1598024587");
+            "https://token-tester.b-cdn.net/300kb.jpg?token=HS256-1-1avZgnR84EtR3eNPVtiOT8RtI9UqcvijgXVU88vxZ60&expires=1598024587");
+    }
+
+    #[test]
+    fn ipv6_compressed_form_matches_expanded() {
+        let expanded = sign_url(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", false, "", "", "", false, Some(EXPIRES_AT), 0,
+        ).unwrap();
+        let compressed = sign_url(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "2001:db8:85a3::8a2e:370:7334", false, "", "", "", false, Some(EXPIRES_AT), 0,
+        ).unwrap();
+        assert_eq!(expanded, compressed);
     }
 
     #[test]
@@ -221,7 +253,7 @@ mod tests {
             SECURITY_KEY, 86400, "2001:0db8:85a3:0000:0000:8a2e:0370:7334", true, "", "CA,US", "", false, Some(EXPIRES_AT), 0,
         ).unwrap();
         assert_eq!(result,
-            "https://token-tester.b-cdn.net/bcdn_token=HS256-om4aK_1Gnb3m2_5WVMtLzD-vlubUyDo1mJ0FFrKU1Kk&token_countries=CA%2CUS&expires=1598024587/abc/");
+            "https://token-tester.b-cdn.net/bcdn_token=HS256-1-TrSbI6dVaWEq8s7tuydKyhJSo9oKHA64KBhb2SgNv0E&token_countries=CA%2CUS&expires=1598024587/abc/");
     }
 
     #[test]
@@ -281,7 +313,7 @@ mod tests {
             SECURITY_KEY, 86400, "1.2.3.4", true, "", "CA,US", "", false, Some(EXPIRES_AT), 0,
         ).unwrap();
         assert_eq!(result,
-            "https://token-tester.b-cdn.net/bcdn_token=HS256-pj8ytucbBWXT_M5cAqKGu4pshB2Q_s28G2uMfjhc3lA&token_countries=CA%2CUS&expires=1598024587/abc/");
+            "https://token-tester.b-cdn.net/bcdn_token=HS256-1-eZuSzuE7KvWxa-lfmEG6eVOp4OmuPlFyzD6acZT8j_o&token_countries=CA%2CUS&expires=1598024587/abc/");
     }
 
     #[test]
@@ -301,7 +333,7 @@ mod tests {
             SECURITY_KEY, 86400, "1.2.3.4", true, "", "", "", false, Some(EXPIRES_AT), 5000,
         ).unwrap();
         assert_eq!(result,
-            "https://token-tester.b-cdn.net/bcdn_token=HS256-9M87MQhNKZqVdjqgHo1IMFVNa01tL2DwlmjBCtou08I&limit=5000&expires=1598024587/abc/");
+            "https://token-tester.b-cdn.net/bcdn_token=HS256-1-NasywRGZDPxXIxBgQ2iyxSP3EWxxok3bzpYhWgaU8BQ&limit=5000&expires=1598024587/abc/");
     }
 
     #[test]
@@ -313,6 +345,24 @@ mod tests {
     #[test]
     fn validation_negative_expiry() {
         let result = sign_url("https://example.com/f.jpg", "key", -1, "", false, "", "", "", false, None, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn no_user_ip_omits_flag_prefix() {
+        let result = sign_url(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "", false, "", "", "", false, Some(EXPIRES_AT), 0,
+        ).unwrap();
+        assert!(!result.contains("HS256-1-"));
+    }
+
+    #[test]
+    fn invalid_ip_returns_error() {
+        let result = sign_url(
+            "https://token-tester.b-cdn.net/300kb.jpg",
+            SECURITY_KEY, 86400, "not-an-ip", false, "", "", "", false, Some(EXPIRES_AT), 0,
+        );
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
This enables IPv6 matching to be less brittle, as well as IP matching without requiring a zone to exclusively IP match payloads.